### PR TITLE
fix short trial description

### DIFF
--- a/lib/Bio/Chado/Schema/Result/Project/Project.pm
+++ b/lib/Bio/Chado/Schema/Result/Project/Project.pm
@@ -36,7 +36,7 @@ __PACKAGE__->table("project");
 
   data_type: 'varchar'
   is_nullable: 0
-  size: 255
+  # note size limit was removed, as it is a text field in the db
 
 =head2 create_date
 
@@ -69,7 +69,7 @@ __PACKAGE__->add_columns(
   "name",
   { data_type => "varchar", is_nullable => 0, size => 255 },
   "description",
-  { data_type => "varchar", is_nullable => 0, size => 255 },
+  { data_type => "varchar", is_nullable => 0 },
   "create_date",
   {
     data_type     => "timestamp",

--- a/lib/Bio/Chado/Schema/Result/Stock/Stockprop.pm
+++ b/lib/Bio/Chado/Schema/Result/Stock/Stockprop.pm
@@ -51,6 +51,12 @@ __PACKAGE__->table("stockprop");
   data_type: 'text'
   is_nullable: 1
 
+=head2 value_jsonb
+
+  data_type: 'text'
+  is_nullable: 1
+
+
 =head2 rank
 
   data_type: 'integer'
@@ -72,7 +78,9 @@ __PACKAGE__->add_columns(
   "type_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
   "value",
-  { data_type => "text", is_nullable => 1 },
+    { data_type => "text", is_nullable => 1 },
+    "value_jsonb",
+    {data_type => "text", is_nullable => 1},
   "rank",
   { data_type => "integer", default_value => 0, is_nullable => 0 },
 );


### PR DESCRIPTION
The trial description is limited in size by the DBIx::Class object. In the database, it is a text field which is practically unlimited (~1GB).  This PR removes the limitation in the DBIx::Class object. 